### PR TITLE
Contact Form 7 PHP commented out

### DIFF
--- a/web/app/themes/coop-tech-oowp-theme/views/frontPage.php
+++ b/web/app/themes/coop-tech-oowp-theme/views/frontPage.php
@@ -251,12 +251,16 @@
 
             <h2>Get In Touch</h2>
             <p>
-                If you would like to work with us, or find out more, get in touch below.
+		If you would like to work with us, or find out more, 
+                <a href="mailto:contact@coops.tech">get in touch</a>.
                 <br/>
-                Not sure which tech coop, or coops, are right for you? Drop us a message and we will help you find the perfect match.
+		Not sure which tech coop, or coops, are right for you? Drop 
+                us a message at 
+                <a href="mailto:contact@coops.tech">contact@coops.tech</a>, 
+                and we will help you find the perfect match.
             </p>
 
-            <?php echo do_shortcode( '[contact-form-7 id="1463" title="contact-form"]' ); ?>
+            <!-- ?php echo do_shortcode( '[contact-form-7 id="1463" title="contact-form"]' ); ? -->
 
             <!-- form>
                 <div class="row">

--- a/web/app/themes/coop-tech-oowp-theme/views/join.php
+++ b/web/app/themes/coop-tech-oowp-theme/views/join.php
@@ -21,7 +21,9 @@
         <div class="row">
             <div class="small-12 medium-6 small-centered columns">
 
-                <?php echo do_shortcode( '[contact-form-7 id="1484" title="join-form"]' ); ?>
+                <p>Contact us via <a href="mailto:contact@coops.tech">contact@coops.tech</a>.</p>
+
+                <!-- ?php echo do_shortcode( '[contact-form-7 id="1484" title="join-form"]' ); ? -->
 
                 <!-- form>
                     <div class="row">


### PR DESCRIPTION
This pull request comments out the PHP, needed by the forms, which were unusable as they had white on white and blue on blue text when accessed using Firefox, see #3.

A better solution would be if someone is able to find the CSS which causes `input` elements to have white on white and blue on blue text with Firefox -- I haven't been able to find the CSS that causes this and I haven't been able to write any CSS rules that override this behaviour, I did spend several hours trying to fix this,

This pull request adds regular `mailto` hyperlinks for the contact address.