### PR TITLE
Bump WordPress version to 4.7.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
     "php": ">=5.4",
     "composer/installers": "~1.0.12",
     "vlucas/phpdotenv": "^2.0.1",
-    "johnpbloch/wordpress": "4.7.4",
+    "johnpbloch/wordpress": "4.7.5",
     "oscarotero/env": "^1.0",
     "wpackagist-plugin/advanced-custom-fields": "4.4.11",
     "wpackagist-plugin/custom-post-type-ui": "1.5.3",


### PR DESCRIPTION
This has been tested on [the dev server](https://dev.coops.tech/) now that #34 has been resolved.