### PR TITLE
Add optional LinkedIn social media link to coop page

### DIFF
--- a/web/app/themes/coop-tech-oowp-theme/inc/acf/co_op.php
+++ b/web/app/themes/coop-tech-oowp-theme/inc/acf/co_op.php
@@ -204,6 +204,7 @@ if(function_exists("register_field_group"))
                             Fields::SNAPCHAT => 'Snapchat',
                             Fields::TWITTER => 'Twitter',
                             Fields::YOUTUBE => 'YouTube',
+                            Fields::LINKED_IN => 'LinkedIn',
                         ),
                         'default_value' => '',
                         'allow_null' => 0,

--- a/web/app/themes/coop-tech-oowp-theme/src/Fields/Fields.php
+++ b/web/app/themes/coop-tech-oowp-theme/src/Fields/Fields.php
@@ -41,5 +41,6 @@ class Fields {
     const SNAPCHAT = 'snapchat';
     const TWITTER = 'twitter';
     const YOUTUBE = 'youtube';
+    const LINKED_IN = 'linkedin';
 
 }

--- a/web/app/themes/coop-tech-oowp-theme/views/coOpSingle.php
+++ b/web/app/themes/coop-tech-oowp-theme/views/coOpSingle.php
@@ -52,6 +52,8 @@
                                         <i class="fi-social-twitter"></i>
                                     <?php elseif ($link[Fields::SOCIAL_MEDIA_TYPE] == Fields::YOUTUBE): ?>
                                         <i class="fi-social-youtube"></i>
+                                    <?php elseif ($link[Fields::SOCIAL_MEDIA_TYPE] == Fields::LINKED_IN): ?>
+                                        <i class="fi-social-linkedin"></i>
                                     <?php endif ?>
                                 </a></li>
                             <?php endforeach ?>


### PR DESCRIPTION
Note that the `linkedin` icon is already available from `foundation-icons`.

Fixes #13