### PR TITLE
Minor changes to support better deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,3 @@ web/favicon.ico
 
 # Generated via crontab
 web/cotech-images.tgz
-

--- a/git-hooks/post-merge
+++ b/git-hooks/post-merge
@@ -5,7 +5,7 @@ echo "==> running post-merge"
 git rev-parse HEAD > commit.txt
 composer update
 cd ./web/app/themes/coop-tech-oowp-theme
-composer update
+composer install
 npm install
 gulp
 ./node_modules/gulp/bin/gulp.js  # in case gulp not in $PATH


### PR DESCRIPTION
The extra entries in .gitignore are currently managed independently on the server, although this could be changed in the future.

There also *should* be a composer.lock file in the `./web/app/themes/coop-tech-oowp-theme` directory :/ Oh well.