### PR TITLE
Fix problems building Docker development environment from scratch

### DIFF
--- a/docker/wordpress/Dockerfile
+++ b/docker/wordpress/Dockerfile
@@ -1,4 +1,4 @@
-FROM adamyeats/docker-nginx-hhvm-bedrock
+FROM outlandish/docker-nginx-hhvm-bedrock
 
 # Allow Composer to run as superuser inside the container
 # https://getcomposer.org/doc/03-cli.md#composer-allow-superuser

--- a/docker/wordpress/docker-entrypoint.sh
+++ b/docker/wordpress/docker-entrypoint.sh
@@ -99,11 +99,8 @@ fi
 
 sed -i 's/listen 80/listen 18080/g' /etc/nginx/sites-enabled/bedrock
 
-chown www-data:www-data /var/run/hhvm/hhvm.hhbc
-
 # bring up our PHP binaries
 /etc/init.d/php5-fpm start
-/etc/init.d/hhvm start
 
 echo >&2 "========================================================================"
 echo >&2

--- a/docker/wordpress/docker-entrypoint.sh
+++ b/docker/wordpress/docker-entrypoint.sh
@@ -100,7 +100,7 @@ fi
 sed -i 's/listen 80/listen 18080/g' /etc/nginx/sites-enabled/bedrock
 
 # bring up our PHP binaries
-/etc/init.d/php5-fpm start
+/etc/init.d/php7.1-fpm start
 
 echo >&2 "========================================================================"
 echo >&2


### PR DESCRIPTION
I cherry-picked the 3 relevant commits from #76 and ran `docker-compose up -d` successfully from scratch. I'm no longer seeing the errors I reported in #65 and the development version of the website seems to work fine as far as I can tell. Thanks, @lwm!

As far as I understand it, the basic problem was that one of the containers was relying on Ubuntu Wily which [reached the end of its life in July 2016](http://fridge.ubuntu.com/2016/07/28/ubuntu-15-10-wily-werewolf-end-of-life-reached-on-july-28-2016/). I believe this PR changes the code to use Xenial instead.

I plan to open a separate PR for the changes to the README that were included in #76.

I don't think the changes to `web/app/themes/coop-tech-oowp-theme/package.json` or `web/app/themes/coop-tech-oowp-theme/yarn.lock` that were included in #76 are really relevant to fixing this problem. I suspect they are just the result of some sort of update that is happening as part of the Docker "build".

Closes #65.