### PR TITLE
Add basic Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+---
+
+sudo: false
+
+language: generic
+
+script:
+  - docker-compose up -d
+  - docker-compose stop

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/cotech/website.svg?branch=master)](https://travis-ci.org/cotech/website)
+
 # Cooperative Technologists
 
 ## Requirements


### PR DESCRIPTION
A start for https://github.com/cotech/website/issues/75.

Got a build over at https://travis-ci.org/lwm/website/builds/359460688.

Someone needs to enable Travis for this repository, I think.

This will just make sure we can always start up the containers.

No idea what to use for testing the pages are up - using a `curl localhost:...` [seems to not really work on Travis for some weird reason](https://travis-ci.org/lwm/website/builds/359467896#L1244-L1256). It'd be nice to have something better in any case. Is there some test framework or something?